### PR TITLE
eswin/ai_driver: type mismatch printing npu_info->peer_type

### DIFF
--- a/drivers/soc/eswin/ai_driver/npu/parse_dep.c
+++ b/drivers/soc/eswin/ai_driver/npu/parse_dep.c
@@ -230,7 +230,7 @@ static void dependency_consumer2producer(struct win_executor *executor,
 		    task->op_desc[i].event_op.submodel_type == E31)
 		{
 			npu_info->peer_type = E31;
-			dla_debug("e31 event op:%d,depcnt:%d,peer_type:%d\n", i,
+			dla_debug("e31 event op:%d,depcnt:%d,peer_type:%lld\n", i,
 			           dependency_count[i], npu_info->peer_type);
 		}
 


### PR DESCRIPTION
npu_info->peer_type is of type u64 (long long unsigned int). For printing we must use %lld.