### PR TITLE
eswin/ai_driver/dsp/dsp_platform: add missing include

### DIFF
--- a/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c
+++ b/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c
@@ -20,6 +20,7 @@
  */
 
 #include <linux/clk.h>
+#include <linux/clk-provider.h>
 #include <linux/interrupt.h>
 #include <linux/io.h>
 #include <linux/module.h>


### PR DESCRIPTION
Avoid a build error:

    drivers/soc/eswin/ai_driver/dsp/dsp_platform.c:
    In function ‘es_dsp_clk_disable’:
    drivers/soc/eswin/ai_driver/dsp/dsp_platform.c:276:19: error:
    implicit declaration of function ‘__clk_is_enabled’;
    did you mean ‘clk_enable’? [-Wimplicit-function-declaration]
      276 |         enabled = __clk_is_enabled(hw->subsys->aclk);
          |                   ^~~~~~~~~~~~~~~~
          |                   clk_enable