### PR TITLE
Fix header includes

### DIFF
--- a/drivers/media/platform/eswin/mipi-csi2/Makefile
+++ b/drivers/media/platform/eswin/mipi-csi2/Makefile
@@ -2,9 +2,9 @@
 #
 # Makefile for Synopsys DWC Platform drivers
 #
-# ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),y)#
-# 	dw-csi-objs += dw-csi-sysfs.o
-# endif
+ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),y)#
+ 	dw-csi-objs += dw-csi-sysfs.o
+endif
 obj-$(CONFIG_DWC_MIPI_CSI2_HOST) += dw-csi.o
 dw-csi-objs := dw-csi-plat.o dw-mipi-csi.o
 

--- a/drivers/memory/eswin/Makefile
+++ b/drivers/memory/eswin/Makefile
@@ -11,6 +11,6 @@ obj-$(CONFIG_ESWIN_IOMMU_RSV)			+= es_iommu_rsv/
 obj-$(CONFIG_ESWIN_DMA_MEMCP)           += es_dma_memcp/
 obj-$(CONFIG_ESWIN_MALLOC_DMABUF)       += es_malloc_dmabuf/
 
-ES_MEM_HEADER := drivers/memory/eswin/
+ES_MEM_HEADER := $(srctree)/drivers/memory/eswin/
 
-COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h include/linux)
+COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h $(srctree)/include/linux)

--- a/drivers/memory/eswin/es_dev_buf/Makefile
+++ b/drivers/memory/eswin/es_dev_buf/Makefile
@@ -1,5 +1,5 @@
 obj-$(CONFIG_ESWIN_DEV_DMA_BUF) += es_dev_buf.o
 
-ES_DEV_DMA_BUF_HEADER := drivers/memory/eswin/es_dev_buf/include/linux
-COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h include/linux)
+ES_DEV_DMA_BUF_HEADER := $(srctree)/drivers/memory/eswin/es_dev_buf/include/linux
+COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h $(srctree)/include/linux)
 

--- a/drivers/memory/eswin/es_proc/Makefile
+++ b/drivers/memory/eswin/es_proc/Makefile
@@ -2,6 +2,6 @@
 obj-$(CONFIG_ESWIN_PROC)	+= es_proc.o
 ccflags-y := -DDEBUG
 
-ES_PROC_HEADER := drivers/memory/eswin/es_proc/include/linux
+ES_PROC_HEADER := $(srctree)/drivers/memory/eswin/es_proc/include/linux
 
-COPY_HEADERS := $(shell cp $(ES_PROC_HEADER)/*.h include/linux)
+COPY_HEADERS := $(shell cp $(ES_PROC_HEADER)/*.h $(srctree)/include/linux)

--- a/drivers/net/wireless/ap12275/Makefile
+++ b/drivers/net/wireless/ap12275/Makefile
@@ -460,7 +460,7 @@ endif
 endif
 
 ARCH ?= riscv
-BCMDHD_ROOT = $(src)
+BCMDHD_ROOT = $(srctree)/drivers/net/wireless/ap12275
 #$(warning "BCMDHD_ROOT=$(BCMDHD_ROOT)")
 EXTRA_CFLAGS = $(DHDCFLAGS)
 EXTRA_CFLAGS += -DDHD_COMPILED=\"$(BCMDHD_ROOT)\"

--- a/drivers/staging/media/eswin/es-media-ext/Makefile
+++ b/drivers/staging/media/eswin/es-media-ext/Makefile
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-only
-ccflags-y := -I$(src)
-ccflags-y += -I$(src)/common/
-ccflags-y += -I$(src)/module/
-ccflags-y += -I$(src)/chn/
-ccflags-y += -I$(src)/proc/
-ccflags-y += -I$(src)/include/
+ccflags-y := -I$(srctree)/drivers/staging/media/eswin/es-media-ext
+ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/common/
+ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/module/
+ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/chn/
+ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/proc/
+ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/include/
 
 es_media_ext_drv-objs := es_media_ext_drv_main.o \
 						./chn/dev_channel.o	\

--- a/sound/soc/codecs/Kconfig
+++ b/sound/soc/codecs/Kconfig
@@ -1060,15 +1060,18 @@ config SND_SOC_ES8326
 
 config SND_SOC_ES8328
 	tristate
+  depends on !ESWIN_SND_ES8388_CODEC
 
 config SND_SOC_ES8328_I2C
 	tristate "Everest Semi ES8328 CODEC (I2C)"
 	depends on I2C
+  depends on !ESWIN_SND_ES8388_CODEC
 	select SND_SOC_ES8328
 
 config SND_SOC_ES8328_SPI
 	tristate "Everest Semi ES8328 CODEC (SPI)"
 	depends on SPI_MASTER
+  depends on !ESWIN_SND_ES8388_CODEC
 	select SND_SOC_ES8328
 
 config SND_SOC_GTM601


### PR DESCRIPTION
Fixes these errors:
```
../drivers/staging/media/eswin/es-media-ext/./chn/dev_channel.h:3:10: fatal error: dev_common.h: No such file or directory
../drivers/staging/media/eswin/es-media-ext/./chn/class_chn_mgr.h:4:10: fatal error: dev_common.h: No such file or directory
../drivers/staging/media/eswin/es-media-ext/./module/dev_module.h:4:10: fatal error: dev_common.h: No such file or directory
../drivers/net/wireless/ap12275/aiutils.c:25:10: fatal error: typedefs.h: No such file or directory
../drivers/net/wireless/ap12275/siutils.c:25:10: fatal error: typedefs.h: No such file or directory
../drivers/memory/eswin/es_mmz_vb/mmz_vb.c:42:10: fatal error: linux/es_proc.h: No such file or directory
../drivers/memory/eswin/es_dev_buf/es_dev_buf.c:10:10: fatal error: linux/dsp_dma_buf.h: No such file or directory
```