### PR TITLE
fix(drivers/drm/eswin): correctly terminate of_device_id

### DIFF
--- a/drivers/gpu/drm/eswin/dw_hdmi_hdcp2.c
+++ b/drivers/gpu/drm/eswin/dw_hdmi_hdcp2.c
@@ -861,6 +861,7 @@ static const struct of_device_id dw_hdmi_hdcp2_dt_ids[] = {
 	{
 		.compatible = "eswin,dw-hdmi-hdcp2",
 	},
+	{ /* end of table */ }
 };
 MODULE_DEVICE_TABLE(of, dw_hdmi_hdcp2_dt_ids);
 


### PR DESCRIPTION
This adds a null value to `of_device_id` so it is correctly terminated.

This is a copy of my [PR to Eswin](https://github.com/eswincomputing/linux-stable/pull/15) that fixes this same issue.